### PR TITLE
update truncation

### DIFF
--- a/lib/stan.js
+++ b/lib/stan.js
@@ -49,7 +49,7 @@ CodeMirror.defineSimpleMode("stan", {
     },
     // truncation
     {
-      regex: /\bT(?=\s*\[)/,
+      regex: /(?<=\))\s*T(?=\s*\[)/,
       token: "keyword"
     },
     // distributions


### PR DESCRIPTION
The current regex will incorrectly highlight `array[N] T[K];` 

If you allow lookbehind (which I saw one use of) then this will only highlight after a closed parenthesis.